### PR TITLE
Avoid mixed content issue with cdn script.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -35,7 +35,7 @@ CKEDITOR.plugins.add('pbckcode', {
             ],
             theme    : 'textmate',
             tab_size : 4,
-            js       : "http://cdn.jsdelivr.net//ace/1.1.4/noconflict///"
+            js       : "//cdn.jsdelivr.net//ace/1.1.4/noconflict///"
         };
 
         // merge user settings with default settings


### PR DESCRIPTION
Sites using https will find that scripts from the ace CDN are blocked by default by browsers that block mixed content protocols. Recommending the use of protocol-relative URL.